### PR TITLE
fix(aowow): fix warnings, switch continue => break

### DIFF
--- a/includes/community.class.php
+++ b/includes/community.class.php
@@ -125,7 +125,7 @@ class CommunityContent
                 case TYPE_ENCHANTMENT: $obj = new EnchantmentList($cnd); break;
                 case TYPE_SOUND:       $obj = new SoundList($cnd);       break;
                 case TYPE_ICON:        $obj = new IconList($cnd);        break;
-                default: continue;
+                default: break;
             }
 
             foreach ($obj->iterate() as $id => $__)

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -1021,8 +1021,9 @@ class Util
                                 $c['ConditionValue1'] = $zone->getField('id');
                                 break;
                             }
-                            else
-                                continue;
+                            else {
+                                break;
+                            }
                     }
                 case CND_ZONEID:                            // 4
                 case CND_AREAID:                            // 23
@@ -1077,7 +1078,7 @@ class Util
                     else if ($c['ConditionValue1'] == 67)   // Horde
                         $c['ConditionValue1'] = 2;
                     else
-                        continue;
+                        break;
             }
 
             $res = [$c['NegativeCondition'] ? -$c['ConditionTypeOrReference'] : $c['ConditionTypeOrReference']];

--- a/pages/genericPage.class.php
+++ b/pages/genericPage.class.php
@@ -853,7 +853,7 @@ class GenericPage
                 case TYPE_USER:        $obj = new UserList($cnd);        break;
                 case TYPE_EMOTE:       $obj = new EmoteList($cnd);       break;
                 case TYPE_ENCHANTMENT: $obj = new EnchantmentList($cnd); break;
-                default: continue;
+                default: break;
             }
 
             $this->extendGlobalData($obj->getJSGlobals(GLOBALINFO_SELF));


### PR DESCRIPTION
Fixed  the followings warnings:
```
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in aowow\includes\utilities.php on line 1025
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in aowow\includes\utilities.php on line 1080
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in aowow\includes\community.class.php on line 128
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in aowow\pages\genericPage.class.php on line 856
```

Converted `continue` into `break` inside the switch statement.

Thx DevCores (discord user) to have reported them.